### PR TITLE
feat(APP-2292): Enable immutable releases for rsynthbio

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,7 +34,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -14,7 +14,6 @@ name: pkgdown
 jobs:
   pkgdown:
     runs-on: ubuntu-latest
-    # Only restrict concurrency for non-PR jobs
     concurrency:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
@@ -22,7 +21,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - uses: r-lib/actions/setup-pandoc@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
 

--- a/.github/workflows/publish_to_cran.yaml
+++ b/.github/workflows/publish_to_cran.yaml
@@ -10,14 +10,18 @@ on:
         description: 'Release notes'
         required: false
 
+permissions: {}
+
 jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         
       - name: Set up R
         uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
@@ -71,7 +75,12 @@ jobs:
           CRAN_PASSWORD: ${{ secrets.CRAN_PASSWORD }}
         run: |
           Rscript -e 'devtools::submit_cran(pkg = Sys.getenv("PACKAGE_PATH"))'
-          
+
+      - name: Generate build provenance attestations
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
+        with:
+          subject-path: ${{ env.PACKAGE_PATH }}
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add SLSA build provenance attestations to the CRAN release workflow via `actions/attest-build-provenance`, generating cryptographically verifiable provenance for the R package tarball
- Upgrade and pin `actions/checkout` from mutable `@v3` tag to immutable SHA (`@v4.2.2`)
- Drop default workflow permissions with `permissions: {}` on the release workflow and add `attestations: write` + `id-token: write` to the release job

These changes complement the repository-level release immutability setting (already enabled) so that the next release produces both GitHub release attestations and SLSA build provenance attestations.

## Test plan

- [ ] Verify CI passes on this PR (R-CMD-check workflow)
- [ ] Confirm next manual release dispatch produces attestations and an immutable GitHub release
- [ ] Verify CRAN submission still works


Made with [Cursor](https://cursor.com)