### PR TITLE
docs(APP-2303): clean up shared docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 To generate datasets without code, use our [web platform](https://app.synthesize.bio/datasets/).
 
-[See the full documentation here](https://synthesizebio.github.io/rsynthbio/).
+[See the full documentation here](https://docs.synthesize.bio/rsynthbio).
 
 For questions, suggestions, and support, email us at [support@synthesize.bio](mailto:support@synthesize.bio).
 
@@ -77,7 +77,6 @@ For detailed usage instructions, start with the shared docs site:
 - [Baseline Models](https://docs.synthesize.bio/rsynthbio/models/baseline) — Generate expression from metadata
 - [Reference Conditioning](https://docs.synthesize.bio/rsynthbio/models/reference-conditioning) — Condition on real expression data
 - [Metadata Prediction](https://docs.synthesize.bio/rsynthbio/models/metadata-prediction) — Infer metadata from expression
-- [Legacy pkgdown site](https://synthesizebio.github.io/rsynthbio/) — Still available for the package-native reference experience
 
 ## Mintlify source
 
@@ -93,7 +92,7 @@ Regenerate the Mintlify docs after changing vignettes, package exports, or roxyg
 python3 scripts/generate_mintlify_docs.py
 ```
 
-The generated pages are committed in `docs-external/` so changes are reviewable in PRs. `docs.synthesize.bio/rsynthbio` is now the canonical shared-docs route, and `pkgdown` remains available alongside it for the package-native reference experience.
+The generated pages are committed in `docs-external/` so changes are reviewable in PRs. `docs.synthesize.bio/rsynthbio` is now the canonical shared-docs route.
 
 ## Rate Limits
 

--- a/README.md
+++ b/README.md
@@ -70,12 +70,14 @@ Only baseline models are available to all users. You can check which models are 
 
 ## Documentation
 
-For detailed usage instructions, see the vignettes:
+For detailed usage instructions, start with the shared docs site:
 
-- [Getting Started](https://synthesizebio.github.io/rsynthbio/articles/getting-started.html) — Installation, authentication, and overview
-- [Baseline Models](https://synthesizebio.github.io/rsynthbio/articles/baseline.html) — Generate expression from metadata
-- [Reference Conditioning](https://synthesizebio.github.io/rsynthbio/articles/reference-conditioning.html) — Condition on real expression data
-- [Metadata Prediction](https://synthesizebio.github.io/rsynthbio/articles/metadata-prediction.html) — Infer metadata from expression
+- [R SDK overview](https://docs.synthesize.bio/rsynthbio) — Canonical public docs landing page
+- [Getting Started](https://docs.synthesize.bio/rsynthbio/getting-started) — Installation, authentication, and overview
+- [Baseline Models](https://docs.synthesize.bio/rsynthbio/models/baseline) — Generate expression from metadata
+- [Reference Conditioning](https://docs.synthesize.bio/rsynthbio/models/reference-conditioning) — Condition on real expression data
+- [Metadata Prediction](https://docs.synthesize.bio/rsynthbio/models/metadata-prediction) — Infer metadata from expression
+- [Legacy pkgdown site](https://synthesizebio.github.io/rsynthbio/) — Still available for the package-native reference experience
 
 ## Mintlify source
 
@@ -91,7 +93,7 @@ Regenerate the Mintlify docs after changing vignettes, package exports, or roxyg
 python3 scripts/generate_mintlify_docs.py
 ```
 
-The generated pages are committed in `docs-external/` so changes are reviewable in PRs. `pkgdown` stays in place during the transition, and GitHub Pages remains the current public docs host until the shared docs site is ready to switch over.
+The generated pages are committed in `docs-external/` so changes are reviewable in PRs. `docs.synthesize.bio/rsynthbio` is now the canonical shared-docs route, and `pkgdown` remains available alongside it for the package-native reference experience.
 
 ## Rate Limits
 


### PR DESCRIPTION
## Summary
- point the README at the live `docs.synthesize.bio/rsynthbio` routes for overview and getting-started content
- keep pkgdown linked as the legacy package-native reference experience
- update the Mintlify-source note now that the shared docs site is live

## Test plan
- not run (README-only changes)

Made with [Cursor](https://cursor.com)