### PR TITLE
chore: CRAN 4.2.0 release prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ To generate datasets without code, use our [web platform](https://app.synthesize
 
 [Get started](https://docs.synthesize.bio/rsynthbio/getting-started) | [Full R SDK docs](https://docs.synthesize.bio/rsynthbio)
 
-For function-level reference, use R's built-in help (`?predict_query`, `help(package = "rsynthbio")`) or the [CRAN reference manual PDF](https://cran.r-project.org/web/packages/rsynthbio/rsynthbio.pdf).
+For function-level reference, use R's built-in help (`?predict_query`, `help(package = "rsynthbio")`) or the [CRAN reference manual](https://CRAN.R-project.org/package=rsynthbio).
 
 For questions, suggestions, and support, email us at [support@synthesize.bio](mailto:support@synthesize.bio).
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ synchronous request and decodes the Apache Arrow IPC stream response into the
 same data frames as the hosted path (no polling, no download URL). It requires
 the optional `arrow` package and does not require an API key.
 
+Self-hosted deployment is a model deployment option available within a
+Synthesize Bio partnership. To learn more or request access, contact
+[partnerships@synthesize.bio](mailto:partnerships@synthesize.bio).
+
 ```r
 install.packages("arrow")
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -4,14 +4,19 @@
 
 ## Release summary
 
-This is a patch release (4.1.0):
+This is a minor release (4.2.0):
 
-- Added output transformer for `gem-1-bulk_predict-metadata` and `gem-1-sc_predict-metadata` that converts results to data.frames.
-- Added output transformer for `gem-1-bulk_condition-on-sample-ids`.
+- Added self-hosted model support: `predict_query()` and `get_example_query()`
+  gain a `self_hosted` argument (also resolved from the `SYNTHESIZE_SELF_HOSTED`
+  environment variable) for querying partner-hosted model containers that
+  return an Apache Arrow IPC stream.
+- Added per-model base-URL resolution via `SYNTHESIZE_API_BASE_URL__<MODEL>`.
+- Self-hosted predictions use a longer 600s request timeout.
 
 ## Test environments
 
 - local macOS (Sequoia 15.7.3), R 4.5.1
+- win-builder (R-devel and R-release)
 - GitHub Actions (ubuntu-24.04, windows-latest, macOS-latest), R release
 
 ## Downstream dependencies

--- a/docs-external/self-hosted.mdx
+++ b/docs-external/self-hosted.mdx
@@ -8,6 +8,12 @@ example, on a GPU host in their own cloud account) can use the same `rsynthbio`
 client against a self-hosted model container instead of the hosted API at
 `app.synthesize.bio`.
 
+<Note>
+  Self-hosted deployment is a model deployment option available within a
+  Synthesize Bio partnership. To learn more or request access, contact
+  [partnerships@synthesize.bio](mailto:partnerships@synthesize.bio).
+</Note>
+
 ## How it differs from the hosted path
 
 The hosted path is asynchronous: it starts a query, polls for completion, and

--- a/vignettes/self-hosted.Rmd
+++ b/vignettes/self-hosted.Rmd
@@ -20,6 +20,10 @@ example, on a GPU host in their own cloud account) can use the same `rsynthbio`
 client against a self-hosted model container instead of the hosted API at
 `app.synthesize.bio`.
 
+> **Self-hosted deployment is a model deployment option available within a
+> Synthesize Bio partnership.** To learn more or request access, contact
+> [partnerships@synthesize.bio](mailto:partnerships@synthesize.bio).
+
 ## How it differs from the hosted path
 
 The hosted path is asynchronous: it starts a query, polls for completion, and


### PR DESCRIPTION
## Summary
- Use the canonical CRAN package URL (`https://CRAN.R-project.org/package=rsynthbio`) in the README, clearing the non-canonical CRAN URL NOTE from `R CMD check --as-cran`.
- Update `cran-comments.md` to describe the 4.2.0 self-hosted release (was stale at 4.1.0) and add win-builder to the test environments.

## Context
Pre-submission prep for the CRAN 4.2.0 release. `R CMD check --as-cran` is clean apart from environment-only noise (local HTML Tidy `<main>`, makeindex artifact, and the benign "unable to verify current time" NOTE) that does not occur on CRAN's build farm. win-builder (R-devel + R-release) checks have been submitted.

## Test plan
- [ ] win-builder R-devel comes back clean
- [ ] win-builder R-release comes back clean

Made with [Cursor](https://cursor.com)